### PR TITLE
fix(install): Use self contained SCPBot

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -128,12 +128,12 @@ if [ "${INSTALL_SCPBOT}" == "true" ]; then
   mkdir /mnt/server/.egg/SCPDBot
 
   echo "Removing old SCPDiscord Bot"
-  rm /mnt/server/.egg/SCPDBot/SCPDiscordBot_Linux
+  rm /mnt/server/.egg/SCPDBot/SCPDiscordBot_Linux_SC
 
   echo "$(tput setaf 4)Installing latest SCP Discord Bot."
-  wget -q https://github.com/KarlOfDuty/SCPDiscord/releases/latest/download/SCPDiscordBot_Linux -P /mnt/server/.egg/SCPDBot
+  wget -q https://github.com/KarlOfDuty/SCPDiscord/releases/latest/download/SCPDiscordBot_Linux_SC -P /mnt/server/.egg/SCPDBot
 
-  chmod +x /mnt/server/.egg/SCPDBot/SCPDiscordBot_Linux
+  chmod 755 /mnt/server/.egg/SCPDBot/SCPDiscordBot_Linux_SC
 
  #Install SCPDiscord Plugin
   echo "Installing Latest SCP Discord Plugin.."


### PR DESCRIPTION
This change fixes an issue with systems running Docker (Pterodactyl).

I ran into the issue when setting up the egg, the docker image does not have a local dotnet binary installed.

By pulling this change, the install script will now pull the 'self-contained' version, introduced as of [Version 3.2.0](https://github.com/KarlOfDuty/SCPDiscord/releases/tag/3.2.0) which doesn't require a local dotnet package and doesn't really increase the file size.